### PR TITLE
tweak classloading logic:

### DIFF
--- a/framework/src/play/classloading/ApplicationClassloader.java
+++ b/framework/src/play/classloading/ApplicationClassloader.java
@@ -439,7 +439,14 @@ public class ApplicationClassloader extends ClassLoader {
                         }
                     }
                 } else {
-                    final int cores = Runtime.getRuntime().availableProcessors() + 1;
+                    int cores = Runtime.getRuntime().availableProcessors() + 1;
+                    String envCores = System.getenv("PARALLEL_CLASSLOADING_THREADS");
+                    if (envCores != null) {
+                        try {
+                            cores = Integer.parseInt(envCores);
+                        } catch (NumberFormatException ignored) {
+                        }
+                    }
                     final ExecutorService executor = Executors.newFixedThreadPool(cores);
 
                     Logger.info("Using %d cores.", cores);


### PR DESCRIPTION
- option to disable parallel classloading
- remove use of synchornized to avoid potential deadlock:
# Found one Java-level deadlock:

"pool-1-thread-33":
  waiting to lock monitor 0x00007f02800180a8 (object 0x0000000606b988f0, a play.classloading.ApplicationClassloader),
  which is held by "pool-1-thread-30"
"pool-1-thread-30":
  waiting to lock monitor 0x00007f02940110b0 (object 0x00000005f1c19f58, a <unknown>),
  which is held by "pool-1-thread-8"
"pool-1-thread-8":
  waiting to lock monitor 0x00007f02800180a8 (object 0x0000000606b988f0, a play.classloading.ApplicationClassloader),
  which is held by "pool-1-thread-30"
